### PR TITLE
Generate coverage report and upload to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
   - ./gradlew download-nativelibs
   - ./gradlew check
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew :safe-app-android:runInstrumentationTests; fi
-
+  - ./gradlew  coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.github.kt3k.coveralls' version '2.8.2'
+}
 allprojects {
     repositories {
         google()
@@ -29,4 +32,13 @@ task delete(type: Delete) {
 
 task Download(dependsOn: ['safe-app:download-nativelibs', 'safe-app-android:download-nativelibs']) {
     // configuration
+}
+
+coveralls {
+    jacocoReportPath 'safe-app/build/reports/jacoco/test/jacocoTestReport.xml'
+    sourceDirs = ["safe-app/src/main/java", "api/src/main/java"]
+}
+
+tasks.coveralls {
+    dependsOn ':safe-app:jacocoTestReport'
 }

--- a/safe-app/build.gradle
+++ b/safe-app/build.gradle
@@ -35,15 +35,13 @@ jacoco {
 }
 jacocoTestReport {
   reports {
-    xml.enabled false
+    xml.enabled true
     csv.enabled false
     html.destination file("${buildDir}/jacocoHtml")
   }
   additionalSourceDirs = files("${rootDir}/api/src/main/java")
   additionalClassDirs = files("${rootDir}/api/build/classes/java/main")
 }
-
-
 
 group 'net.maidsafe'
 version '0.1.0'

--- a/safe-app/build.gradle
+++ b/safe-app/build.gradle
@@ -16,6 +16,7 @@ plugins {
 }
 
 apply plugin: 'java-library'
+apply plugin: 'jacoco'
 apply plugin: 'idea'
 apply plugin: "com.github.johnrengelman.shadow"
 
@@ -29,6 +30,21 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 pmd {
     pmdTest.enabled = false
 }
+jacoco {
+  toolVersion = "0.8.1"
+}
+jacocoTestReport {
+  reports {
+    xml.enabled false
+    csv.enabled false
+    html.destination file("${buildDir}/jacocoHtml")
+  }
+  additionalSourceDirs = files("${rootDir}/api/src/main/java")
+  additionalClassDirs = files("${rootDir}/api/build/classes/java/main")
+}
+
+
+
 group 'net.maidsafe'
 version '0.1.0'
 
@@ -166,6 +182,11 @@ task('pack') {
     }
 }
 test {
+  jacoco {
+    append = false
+    destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
+    classDumpDir = file("$buildDir/jacoco/classpathdumps")
+  }
   testLogging {
     events "PASSED", "FAILED", "SKIPPED"
     exceptionFormat "full"

--- a/safe-app/src/test/java/net/maidsafe/api/MDataTest.java
+++ b/safe-app/src/test/java/net/maidsafe/api/MDataTest.java
@@ -34,8 +34,8 @@ public class MDataTest {
     static final int TYPE_TAG = 15001;
 
 
-    private void publicMDataCrud(final MDataInfo mDataInfo) throws Exception {
-        Session session = TestHelper.createSession();
+    private void publicMDataCrud(final MDataInfo mDataInfo, final Session session) throws Exception {
+        NativeHandle appPublicSignKey = session.crypto.getAppPublicSignKey().get();
         PermissionSet permissionSet = new PermissionSet();
         permissionSet.setInsert(true);
         permissionSet.setUpdate(true);
@@ -43,7 +43,7 @@ public class MDataTest {
         permissionSet.setDelete(true);
         permissionSet.setManagePermission(true);
         NativeHandle permissionHandle = session.mDataPermission.newPermissionHandle().get();
-        session.mDataPermission.insert(permissionHandle, session.crypto.getAppPublicSignKey().get(),
+        session.mDataPermission.insert(permissionHandle, appPublicSignKey,
                 permissionSet).get();
         NativeHandle entriesHandle = session.mDataEntries.newEntriesHandle().get();
         session.mDataEntries.insert(entriesHandle, "someKey".getBytes(), "someValue".getBytes()).get();
@@ -96,7 +96,7 @@ public class MDataTest {
                 new String(values.get(0).getContent()));
 
         PermissionSet permissions = session.mData.getPermissionForUser(
-                session.crypto.getAppPublicSignKey().get(), mdInfo).get();
+                appPublicSignKey, mdInfo).get();
         Assert.assertTrue(permissions.getInsert());
         Assert.assertTrue(permissions.getUpdate());
         Assert.assertTrue(permissions.getRead());
@@ -108,16 +108,15 @@ public class MDataTest {
         permissionSet.setRead(false);
         permissionSet.setDelete(false);
         permissionHandle = session.mDataPermission.newPermissionHandle().get();
-        session.mDataPermission.insert(permissionHandle, session.crypto.getAppPublicSignKey().get(),
+        session.mDataPermission.insert(permissionHandle, appPublicSignKey,
                 permissionSet).get();
-        session.mData.setUserPermission(session.crypto.getAppPublicSignKey().get(), mdInfo,
+        session.mData.setUserPermission(appPublicSignKey, mdInfo,
                 permissionSet, session.mData.getVersion(mdInfo).get() + 1).get();
         long version = session.mData.getVersion(mdInfo).get();
         Assert.assertEquals(1, version);
     }
 
-    private void privateMDataCrud(final MDataInfo mDataInfo) throws Exception {
-        Session session = TestHelper.createSession();
+    private void privateMDataCrud(final MDataInfo mDataInfo, final Session session) throws Exception {
         PermissionSet permissionSet = new PermissionSet();
         permissionSet.setInsert(true);
         permissionSet.setUpdate(true);
@@ -179,16 +178,17 @@ public class MDataTest {
         Session session = TestHelper.createSession();
         long tagType = TYPE_TAG;
         MDataInfo mDataInfo = session.mData.getRandomPublicMData(tagType).get();
-        publicMDataCrud(mDataInfo);
+        publicMDataCrud(mDataInfo, session);
     }
 
     @Test
     public void publicMDataCRUDTest() throws Exception {
+        Session session = TestHelper.createSession();
         long tagType = TYPE_TAG;
         MDataInfo mDataInfo = new MDataInfo();
         mDataInfo.setName(Helper.randomAlphaNumeric(Constants.XOR_NAME_LENGTH).getBytes());
         mDataInfo.setTypeTag(tagType);
-        publicMDataCrud(mDataInfo);
+        publicMDataCrud(mDataInfo, session);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class MDataTest {
         Session session = TestHelper.createSession();
         long tagType = TYPE_TAG;
         MDataInfo mDataInfo = session.mData.getRandomPrivateMData(tagType).get();
-        privateMDataCrud(mDataInfo);
+        privateMDataCrud(mDataInfo, session);
     }
 
     @Test
@@ -209,6 +209,6 @@ public class MDataTest {
                 .get();
         MDataInfo mDataInfo = session.mData.getPrivateMData(Helper.randomAlphaNumeric(
                 Constants.XOR_NAME_LENGTH).getBytes(), tagType, secretKey, nonce).get();
-        privateMDataCrud(mDataInfo);
+        privateMDataCrud(mDataInfo, session);
     }
 }


### PR DESCRIPTION
Added a plugin for jacoco and made jacoco generate tests for all sub-modules by providing the additional source directories.'
Added a plugin for coveralls and specified the path for it to fetch the files.
Reduced the no of API calls in MData tests.
