### PR TITLE
Add coverage report and integrated coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         github-token: $GH_ACCESS_TOKEN
         local_dir: safe-app-android/build/docs/javadoc
         on:
+          repo: maidsafe/safe_app_java
           branch: master
     - os: osx
       language: java
@@ -39,4 +40,4 @@ script:
   - ./gradlew download-nativelibs
   - ./gradlew check
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew :safe-app-android:runInstrumentationTests; fi
-
+  - ./gradlew  coveralls

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ safe_app_java is a Java wrapper for the [safe_app](https://github.com/maidsafe/s
 
 **Maintainer:** Krishna Kumar (krishna.kumar@maidsafe.net)
 
-|Android|
-|:-:|
-|[![Build Status](https://travis-ci.com/maidsafe/safe_app_java.svg?branch=master)](https://travis-ci.com/maidsafe/safe_app_java)|
+|Android|Coverage Status|
+|:---:|:---:|
+|[![Build Status](https://travis-ci.com/maidsafe/safe_app_java.svg?branch=master)](https://travis-ci.com/maidsafe/safe_app_java)|[![Coverage Status](https://coveralls.io/repos/github/maidsafe/safe_app_java/badge.svg?branch=master)](https://coveralls.io/github/maidsafe/safe_app_java?branch=master)|
 
 
 ## API Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.github.kt3k.coveralls' version '2.8.2'
+}
 allprojects {
     repositories {
         google()
@@ -29,4 +32,13 @@ task delete(type: Delete) {
 
 task Download(dependsOn: ['safe-app:download-nativelibs', 'safe-app-android:download-nativelibs']) {
     // configuration
+}
+
+coveralls {
+    jacocoReportPath 'safe-app/build/reports/jacoco/test/jacocoTestReport.xml'
+    sourceDirs = ["safe-app/src/main/java", "api/src/main/java"]
+}
+
+tasks.coveralls {
+    dependsOn ':safe-app:jacocoTestReport'
 }

--- a/safe-app/build.gradle
+++ b/safe-app/build.gradle
@@ -35,15 +35,13 @@ jacoco {
 }
 jacocoTestReport {
   reports {
-    xml.enabled false
+    xml.enabled true
     csv.enabled false
     html.destination file("${buildDir}/jacocoHtml")
   }
   additionalSourceDirs = files("${rootDir}/api/src/main/java")
   additionalClassDirs = files("${rootDir}/api/build/classes/java/main")
 }
-
-
 
 group 'net.maidsafe'
 version '0.1.0'

--- a/safe-app/build.gradle
+++ b/safe-app/build.gradle
@@ -16,6 +16,7 @@ plugins {
 }
 
 apply plugin: 'java-library'
+apply plugin: 'jacoco'
 apply plugin: 'idea'
 apply plugin: "com.github.johnrengelman.shadow"
 
@@ -29,6 +30,21 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 pmd {
     pmdTest.enabled = false
 }
+jacoco {
+  toolVersion = "0.8.1"
+}
+jacocoTestReport {
+  reports {
+    xml.enabled false
+    csv.enabled false
+    html.destination file("${buildDir}/jacocoHtml")
+  }
+  additionalSourceDirs = files("${rootDir}/api/src/main/java")
+  additionalClassDirs = files("${rootDir}/api/build/classes/java/main")
+}
+
+
+
 group 'net.maidsafe'
 version '0.1.0'
 
@@ -167,6 +183,11 @@ task('pack') {
     }
 }
 test {
+  jacoco {
+    append = false
+    destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
+    classDumpDir = file("$buildDir/jacoco/classpathdumps")
+  }
   testLogging {
     events "PASSED", "FAILED", "SKIPPED"
     exceptionFormat "full"


### PR DESCRIPTION
Use Jacoco to generate code coverage report in XML.
Upload coverage report to coveralls.io
closes #70 
closes #71