### PR TITLE
Deprecate get serialised size API

### DIFF
--- a/api/src/main/java/net/maidsafe/api/IData.java
+++ b/api/src/main/java/net/maidsafe/api/IData.java
@@ -145,7 +145,9 @@ public class IData {
      * Get size of the serialised Immutable Data
      * @param address Address of the Immutable Data
      * @return Size of the serialised Immutable Data
+     * @deprecated This API will be removed in the next release
      */
+    @Deprecated
     public CompletableFuture<Long> getSerialisedSize(final byte[] address) {
         final CompletableFuture<Long> future = new CompletableFuture<>();
         NativeBindings.idataSerialisedSize(appHandle.toLong(), address, (result, size) -> {


### PR DESCRIPTION
The `getSerialisedSize` API is used returned the size of the serialised data map. Serialisation of the data-map is no  longer exposed and hence this API can be deprecated.