### PR TITLE
Add artifacts to Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,10 @@ clone_folder: "C:\\projects\\safe_app_java"
 init:
   - cd "C:\projects\safe_app_java"
   - git config --global core.autocrlf true
-build: off
-test_script:
+build_script:
   - gradlew.bat download-nativelibs
   - gradlew.bat check
+on_failure:
+  - 7z a reports.zip safe-app/build/reports/ lib/build/reports/ api/build/reports/
+  - cmd: appveyor PushArtifact reports.zip
+

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,20 @@ subprojects {
         ruleSets = ["$rootDir/config/pmd/pmd-ruleset.xml"]
     }
 
+    tasks.withType(Pmd) {
+        reports {
+            xml.enabled false
+            html.enabled true
+        }
+    }
+
     tasks.withType(Checkstyle) {
         exclude "**/net/maidsafe/safe_app/*"
         exclude "**/net/maidsafe/safe_authenticator/*"
+        reports {
+            html.enabled = true
+            xml.enabled = false
+        }
     }
 }
 task delete(type: Delete) {


### PR DESCRIPTION
Add PMD, stylecheck and spotbugs as artifacts to Appveyor to download and review the build results if a build fails.

closes #77  