### PR TITLE
chore/iData: deprecate getSerialisedSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 ### Added
 - Added tests for mutable data
 - Added tests for Client
+
+### Removed
+- Removed getSerialisedSize API from immutable data

--- a/api/src/main/java/net/maidsafe/api/IData.java
+++ b/api/src/main/java/net/maidsafe/api/IData.java
@@ -145,8 +145,9 @@ public class IData {
      * Get size of the serialised Immutable Data
      * @param address Address of the Immutable Data
      * @return Size of the serialised Immutable Data
+     * @deprecated This method will be removed
      */
-    public CompletableFuture<Long> getSerialisedSize(final byte[] address) {
+    @Deprecated public CompletableFuture<Long> getSerialisedSize(final byte[] address) {
         final CompletableFuture<Long> future = new CompletableFuture<>();
         NativeBindings.idataSerialisedSize(appHandle.toLong(), address, (result, size) -> {
             if (result.getErrorCode() != 0) {


### PR DESCRIPTION
The `getSerialisedSize` function for iData does not have a valid use case and deprecated.

solves #87 